### PR TITLE
Modified the Orb to use the $HOME env var

### DIFF
--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -40,7 +40,7 @@ commands:
                 curl -L https://get.pulumi.com/ | bash -s -- --version << parameters.version >>
               fi
               # Add to PATH
-              echo 'export PATH=/home/circleci/.pulumi/bin:$PATH' >> $BASH_ENV
+              echo 'export PATH=${HOME}/.pulumi/bin:$PATH' >> $BASH_ENV
               source $BASH_ENV
       - run:
           name: "Log into Pulumi"


### PR DESCRIPTION
The login function specified a static path to the circleci user's home path `/home/circleci/` which breaks on non-circleci executor images. I changed the path to use the `${HOME}` env var so which should work on Linux image.