### PR TITLE
Add destroy and refresh orb

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ The `update` orb performs an update to a given Pulumi stack.
 
 ### pulumi/destroy
 
-The `destroy` orb destroys a given Pulumi stack.
+The `destroy` orb destroys a given Pulumi stack and its resources. After running to completion, all of this stack’s resources and associated state will be gone.
+
+Warning: this command is generally irreversible and should be used with great care.
 
 | Parameter         | type    | default     | description    |
 |-------------------|---------|-------------|----------------|
@@ -107,10 +109,11 @@ The `destroy` orb destroys a given Pulumi stack.
 
 ### pulumi/refresh
 
-The `refresh` orb performs a refresh to a given Pulumi stack.
+The `refresh` orb performs a refresh to a given Pulumi stack. The stack’s resource state is compared to the current state known in the cloud provider, and the stack's resources are updated as necessary. No changes will be made to the resources on the cloud provider, but resources that can no longer be found will be removed from the stack.
 
 | Parameter         | type    | default     | description    |
 |-------------------|---------|-------------|----------------|
 | stack           | string  | (none)      | Name of the Pulumi stack to refresh. |
+| expect_no_changes | boolean | false | If set, Pulumi will report an error if any resource changes are detected. | 
 | working_directory | string | . | The relative working directory to run `pulumi` from. | 
 | skip-preview | boolean | false | Whether or not to skip the preview step before the refresh. | 

--- a/README.md
+++ b/README.md
@@ -94,3 +94,23 @@ The `update` orb performs an update to a given Pulumi stack.
 | stack           | string  | (none)      | Name of the Pulumi stack to update. |
 | working_directory | string | . | The relative working directory to run `pulumi` from. | 
 | skip-preview | boolean | false | Whether or not to skip the preview step before the update. | 
+
+### pulumi/destroy
+
+The `destroy` orb destroys a given Pulumi stack.
+
+| Parameter         | type    | default     | description    |
+|-------------------|---------|-------------|----------------|
+| stack           | string  | (none)      | Name of the Pulumi stack to destroy. |
+| working_directory | string | . | The relative working directory to run `pulumi` from. | 
+| skip-preview | boolean | false | Whether or not to skip the preview step before destroying the stack. | 
+
+### pulumi/refresh
+
+The `refresh` orb performs a refresh to a given Pulumi stack.
+
+| Parameter         | type    | default     | description    |
+|-------------------|---------|-------------|----------------|
+| stack           | string  | (none)      | Name of the Pulumi stack to refresh. |
+| working_directory | string | . | The relative working directory to run `pulumi` from. | 
+| skip-preview | boolean | false | Whether or not to skip the preview step before the refresh. | 

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -125,7 +125,47 @@ commands:
       - run: 
           name: "pulumi update --stack << parameters.stack >>"
           command: pulumi update --stack << parameters.stack >> --cwd << parameters.working_directory >> <<# parameters.skip-preview >>--skip-preview<</ parameters.skip-preview >>
-  
+
+  # destroy command
+  destroy:
+    parameters:
+      stack:
+        type: string
+        description: "Name of the Pulumi stack to destroy."
+      working_directory:
+        type: string
+        description:
+            "The relative working directory to use, i.e. where your Pulumi.yaml is located."
+        default: "."
+      skip-preview:
+        type: boolean
+        description: "Do not perform a preview before performing the destroy."
+        default: false
+    steps:
+      - run: 
+          name: "pulumi destroy --stack << parameters.stack >>"
+          command: pulumi destroy --stack << parameters.stack >> --cwd << parameters.working_directory >> <<# parameters.skip-preview >>--skip-preview<</ parameters.skip-preview >>
+
+  # refresh command
+  refresh:
+    parameters:
+      stack:
+        type: string
+        description: "Name of the Pulumi stack to refresh."
+      working_directory:
+        type: string
+        description:
+            "The relative working directory to use, i.e. where your Pulumi.yaml is located."
+        default: "."
+      skip-preview:
+        type: boolean
+        description: "Do not perform a preview before performing the refresh."
+        default: false
+    steps:
+      - run: 
+          name: "pulumi refresh --stack << parameters.stack >>"
+          command: pulumi refresh --stack << parameters.stack >> --cwd << parameters.working_directory >> <<# parameters.skip-preview >>--skip-preview<</ parameters.skip-preview >>
+
 examples:
   login_example:
     description:

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -152,6 +152,10 @@ commands:
       stack:
         type: string
         description: "Name of the Pulumi stack to refresh."
+      expect_no_changes:
+        type: boolean
+        description: "If set, Pulumi will report an error if any resource changes are detected."
+        default: false
       working_directory:
         type: string
         description:
@@ -164,7 +168,7 @@ commands:
     steps:
       - run: 
           name: "pulumi refresh --stack << parameters.stack >>"
-          command: pulumi refresh --stack << parameters.stack >> --cwd << parameters.working_directory >> <<# parameters.skip-preview >>--skip-preview<</ parameters.skip-preview >>
+          command: pulumi refresh --stack << parameters.stack >> <<# parameters.expect_no_changes >>--expect-no-changes<</ parameters.expect_no_changes >> --cwd << parameters.working_directory >> <<# parameters.skip-preview >>--skip-preview<</ parameters.skip-preview >>
 
 examples:
   login_example:


### PR DESCRIPTION
Add `pulumi destroy` and `pulumi refresh` command to the orb.
Closes #16 and closes #9.

The two orbs are almost just a copy of `pulumi update`.