### PR TITLE
Add stack output orb

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ The `stack_rm` orb removes a stack and its configuration..
 | force | boolean | false | Whether or not to force deletion of the stack, leaving behind any resources managed by the stack. | 
 | working_directory | string | . | The relative working directory to run `pulumi` from. | 
 
+### pulumi/stack_output
+
+The `stack_output` sets a stack's output property to an environment variable.
+
+| Parameter         | type    | default     | description    |
+|-------------------|---------|-------------|----------------|
+| stack           | string  | (none)      | Name of the stack to remove. |
+| property_name           | string  | (none)      | Property name of the stack output to set to the environment variable. |
+| env_var           | string  | (none)      | Name of the environment variable to set the output property's value to. |
+| log_to_stderr | boolean | true | Log to stderr instead of to files. | 
+| working_directory | string | . | The relative working directory to run `pulumi` from. | 
+
 ### pulumi/preview
 
 The `preview` orb performs a preview of the update to a given Pulumi stack.

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ The `stack_output` sets a stack's output property to an environment variable.
 
 | Parameter         | type    | default     | description    |
 |-------------------|---------|-------------|----------------|
-| stack           | string  | (none)      | Name of the stack to remove. |
-| property_name           | string  | (none)      | Property name of the stack output to set to the environment variable. |
+| stack           | string  | (none)      | Name of the stack to read the output property from. |
+| property_name           | string  | (none)      | Name of the output property to read. |
 | env_var           | string  | (none)      | Name of the environment variable to set the output property's value to. |
-| log_to_stderr | boolean | true | Log to stderr instead of to files. | 
+| show_secrets | boolean | false | Display stack outputs which are marked as secret in plaintext. | 
 | working_directory | string | . | The relative working directory to run `pulumi` from. | 
 
 ### pulumi/preview

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -264,7 +264,7 @@ examples:
               # and deploy it.
               - pulumi/stack_init:
                   stack: robot-co/test-pr_${CIRCLE_BUILD_NUM}
-              - pulumi/update
+              - pulumi/update:
                   stack: robot-co/test-pr_${CIRCLE_BUILD_NUM}
 
               # Now that the stack has been created, retrieve one of its

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -264,7 +264,8 @@ examples:
               # and deploy it.
               - pulumi/stack_init:
                   stack: robot-co/test-pr_${CIRCLE_BUILD_NUM}
-              - pulumi/stack_update
+              - pulumi/update
+                  stack: robot-co/test-pr_${CIRCLE_BUILD_NUM}
 
               # Now that the stack has been created, retrieve one of its
               # output properties. e.g. the URL it is running at.

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -102,10 +102,10 @@ commands:
       env_var:
         type: string
         description: "Name of the environment variable to set the output property's value to."
-      log_to_stderr:
+      show_secrets:
         type: boolean
-        description: "Log to stderr instead of to files. Default true."
-        default: true
+        description: "Display stack outputs which are marked as secret in plaintext."
+        default: false
       working_directory:
         type: string
         description:
@@ -115,7 +115,7 @@ commands:
       - run:
           name: "pulumi stack output << parameters.property_name >> --stack << parameters.stack >>"
           command: | 
-            OUTPUT_VALUE=$(pulumi stack output << parameters.property_name >> --stack << parameters.stack >> <<# parameters.log_to_stderr >>--logtostderr<</ parameters.log_to_stderr >> --cwd << parameters.working_directory >>)
+            OUTPUT_VALUE=$(pulumi stack output << parameters.property_name >> --stack << parameters.stack >> <<# parameters.show_secrets >>--show-secrets<</ parameters.show_secrets >> --cwd << parameters.working_directory >>)
             echo 'export << parameters.env_var >>="${OUTPUT_VALUE}"' >> $BASH_ENV
 
   # preview command
@@ -252,16 +252,32 @@ examples:
           working_directory: ~/repo/
           steps:
               - checkout
-              - build # ?
+
+              # Install any dependencies and build the Pulumi program.
+              - build
+
+              # Create a new Pulumi stack specifically for testing the
+              # new infrastructure changes.
               - pulumi/login
+
+              # Create a new stack, specific to this CircleCI build,
+              # and deploy it.
               - pulumi/stack_init:
-                  stack: robot-co/test-pr_<< include CircleCI job number? >>
+                  stack: robot-co/test-pr_${CIRCLE_BUILD_NUM}
               - pulumi/stack_update
+
+              # Now that the stack has been created, retrieve one of its
+              # output properties. e.g. the URL it is running at.
               - pulumi/stack_output:
-                  stack: robot-co/test-pr_<< include CircleCI job number? >>
+                  stack: robot-co/test-pr_${CIRCLE_BUILD_NUM}
                   property_name: awsLambdaUrl
                   env_var: TEST_URL
+
+              # Run tests against the newly deployed Pulumi stack.
               - run_tests $TEST_URL
+
+              # After testing is complete, tear down the resources
+              # and delete the stack.
               - pulumi/destroy
               - pulumi/stack_rm:
-                  stack: robot-co/test-pr_<< include CircleCI job number? >>
+                  stack: robot-co/test-pr_${CIRCLE_BUILD_NUM}

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -90,6 +90,34 @@ commands:
           name: "pulumi stack rm << parameters.stack >>"
           command: pulumi stack rm << parameters.stack >> <<# parameters.force >>--force<</ parameters.force >> --cwd << parameters.working_directory >>
 
+  # stack output command
+  stack_output:
+    parameters:
+      stack:
+        type: string
+        description: "Name of the stack to operate on."
+      property_name:
+        type: string
+        description: "Property name of the stack output to set to the environment variable."
+      env_var:
+        type: string
+        description: "Name of the environment variable to set the output property's value to."
+      log_to_stderr:
+        type: boolean
+        description: "Log to stderr instead of to files. Default true."
+        default: true
+      working_directory:
+        type: string
+        description:
+            "The relative working directory to use, i.e. where your Pulumi.yaml is located."
+        default: "."
+    steps:
+      - run:
+          name: "pulumi stack output << parameters.property_name >> --stack << parameters.stack >>"
+          command: | 
+            OUTPUT_VALUE=$(pulumi stack output << parameters.property_name >> --stack << parameters.stack >> <<# parameters.log_to_stderr >>--logtostderr<</ parameters.log_to_stderr >> --cwd << parameters.working_directory >>)
+            echo 'export << parameters.env_var >>="${OUTPUT_VALUE}"' >> $BASH_ENV
+
   # preview command
   preview:
     parameters:
@@ -208,3 +236,32 @@ examples:
             - pulumi/update:
                 stack: robot-co/website-prod
                 working_directory: ~/repo/src/website/
+
+  review_app_example:
+    description:
+        "Creates a new Pulumi stack and deploys the source code built as part of the workflow, running
+        tests against it. When complete, tears down the stack and cleans up any cloud resources."
+    usage:
+      version: 2.1
+      orbs:
+        pulumi: pulumi/pulumi@1.0.0
+      jobs:
+        build:
+          docker:
+            - image: circleci/node:10
+          working_directory: ~/repo/
+          steps:
+              - checkout
+              - build # ?
+              - pulumi/login
+              - pulumi/stack_init:
+                  stack: robot-co/test-pr_<< include CircleCI job number? >>
+              - pulumi/stack_update
+              - pulumi/stack_output:
+                  stack: robot-co/test-pr_<< include CircleCI job number? >>
+                  property_name: awsLambdaUrl
+                  env_var: TEST_URL
+              - run_tests $TEST_URL
+              - pulumi/destroy
+              - pulumi/stack_rm:
+                  stack: robot-co/test-pr_<< include CircleCI job number? >>

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -116,7 +116,7 @@ commands:
           name: "pulumi stack output << parameters.property_name >> --stack << parameters.stack >>"
           command: | 
             OUTPUT_VALUE=$(pulumi stack output << parameters.property_name >> --stack << parameters.stack >> <<# parameters.show_secrets >>--show-secrets<</ parameters.show_secrets >> --cwd << parameters.working_directory >>)
-            echo 'export << parameters.env_var >>="${OUTPUT_VALUE}"' >> $BASH_ENV
+            echo "export << parameters.env_var >>=\"${OUTPUT_VALUE}\"" >> $BASH_ENV
 
   # preview command
   preview:


### PR DESCRIPTION
Related issue: #15 

Here's an initial implementation of `stack output [property-name]` for the orbs.

I've come to a conclusion that the priority to be able to use the output **across jobs** is not the responsibility of this orb. Hence I'm only setting the value to the specified environment variable inside the orb. Any other opinions about this approach is greatly appreciated!

I wasn't sure if the following flags are needed or not:

```
      --disable-integrity-checking   Disable integrity checking of checkpoint files
  -e, --emoji                        Enable emojis in the output
      --logflow                      Flow log settings to child processes (like plugins)
      --non-interactive              Disable interactive mode for all commands
      --profiling string             Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
  -i, --show-ids                     Display each resource's provider-assigned unique ID
      --show-secrets                 Display stack outputs which are marked as secret in plaintext
  -u, --show-urns                    Display each resource's Pulumi-assigned globally unique URN
      --tracing file:                Emit tracing to the specified endpoint. Use the file: scheme to write tracing data to a local file
  -v, --verbose int                  Enable verbose logging (e.g., v=3); anything >3 is very verbose
```

Also, I haven't tested this approach yet so am planning to create a simple CI example for a PoC. Theoretically, it should work.