### PR TITLE
Add --yes option to stack_rm

### DIFF
--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -88,7 +88,7 @@ commands:
     steps:
       - run:
           name: "pulumi stack rm << parameters.stack >>"
-          command: pulumi stack rm << parameters.stack >> <<# parameters.force >>--force<</ parameters.force >> --cwd << parameters.working_directory >>
+          command: pulumi stack rm << parameters.stack >> --yes <<# parameters.force >>--force<</ parameters.force >> --cwd << parameters.working_directory >>
 
   # stack output command
   stack_output:


### PR DESCRIPTION
A quick fix for the `stack_rm` orb.

Currently, the non-interactive mode is not respected in pulumi cli, so
this forces a --yes option to ignore the prompts.

Tested here:
https://github.com/kenfdev/pulumi-stack-output-sample/blob/master/.circleci/config.yml#L53

Closes #21

Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>