### PR TITLE
Chore fix to apply best practices

### DIFF
--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -206,7 +206,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        pulumi: pulumi/pulumi@1.0.0
+        pulumi: pulumi/pulumi@x.y
       jobs:
         build:
           docker:
@@ -224,7 +224,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        pulumi: pulumi/pulumi@1.0.0
+        pulumi: pulumi/pulumi@x.y
       jobs:
         build:
           docker:
@@ -244,7 +244,7 @@ examples:
     usage:
       version: 2.1
       orbs:
-        pulumi: pulumi/pulumi@1.0.0
+        pulumi: pulumi/pulumi@x.y
       jobs:
         build:
           docker:

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -10,7 +10,12 @@ description:
     The Pulumi Orbs for CircleCI enables you to use easily integrate Pulumi
     into your CircleCI workflows.
     
-    Repo: https://circleci.com/orbs/registry/orb/pulumi/pulumi"
+    Repo: https://circleci.com/orbs/registry/orb/pulumi/pulumi
+
+    Follow the instructions here to obtain the Pulumi Access Token:
+    https://www.pulumi.com/docs/intro/console/accounts-and-organizations/accounts/#access-tokens"
+
+    
 
 commands:
 


### PR DESCRIPTION
Some simple fixes to apply the best practices. I was a bit skeptic about the version written in `x.y` but looking at the slack orb, it actually means to write as `x.y`. Hence I changed it.

https://github.com/CircleCI-Public/slack-orb/blob/staging/src/examples/approval.yml#L7

Also added a description of the access token.

Related issue: #8 