### PR TITLE
add --suppress-permalink support to preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The `preview` orb performs a preview of the update to a given Pulumi stack.
 |-------------------|---------|-------------|----------------|
 | stack           | string  | (none)      | Name of the Pulumi stack to preview. |
 | working_directory | string | . | The relative working directory to run `pulumi` from. | 
+| suppress_permalink | boolean | false | Suppress display of the state permalink. |
 
 ### pulumi/update
 

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -135,10 +135,14 @@ commands:
         description:
             "The relative working directory to use, i.e. where your Pulumi.yaml is located."
         default: "."
+      suppress_permalink:
+        type: boolean
+        description: "Suppress display of the state permalink."
+        default: false
     steps:
       - run:
           name: "pulumi preview --stack << parameters.stack >>"
-          command: pulumi preview --stack << parameters.stack >> --cwd << parameters.working_directory >>
+          command: pulumi preview --stack << parameters.stack >> --cwd << parameters.working_directory >> <<# parameters.suppress_permalink >>--suppress-permalink<</ parameters.suppress_permalink >>
 
   # update command
   update:


### PR DESCRIPTION
I was evaluating using the pulumi orb for some of our circleci configurations and one of the features that we want is the ability to be able to use the `--suppress-permalink` flag when executing `pulumi preview`