### PR TITLE
(feat): Add --copy-config-from flag option to stack init

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ parameter.
 | stack           | string  | (none)      | Name of the stack to initialize. |
 | secrets_provider | string  | default      | The type of the provider that should be used to encrypt and decrypt secrets (possible choices: default, passphrase, awskms, azurekeyvault, gcpkms, hashivault). |
 | working_directory | string | . | The relative working directory to run `pulumi` from. | 
+| copy | boolean | false      | Copies config from an existing stack (default false) |
+| stack_config_copy  | string  | (none)     | The stack name to copy from |
 
 ### pulumi/stack_rm
 

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -71,10 +71,18 @@ commands:
         description:
             "The relative working directory to use, i.e. where your Pulumi.yaml is located."
         default: "."
+      copy:
+        type: boolean
+        description: "Copies config from an existing stack (default false)"
+        default: false
+      stack_config_copy:
+        type: string
+        description: "The stack name to copy from"
+        default: ""
     steps:
       - run:
           name: "pulumi stack init --stack << parameters.stack >> --secrets-provider << parameters.secrets_provider >>"
-          command: pulumi stack init --stack << parameters.stack >> --secrets-provider << parameters.secrets_provider >> --cwd << parameters.working_directory >>
+          command: pulumi stack init --stack << parameters.stack >> --secrets-provider << parameters.secrets_provider >> --cwd << parameters.working_directory >> <<# parameters.copy >>--copy-config-from << parameters.stack_config_copy >><</ parameters.copy >>
 
   # stack rm command
   stack_rm:


### PR DESCRIPTION
The `stack-init` command is missing one of the flags from [the CLI](https://www.pulumi.com/docs/reference/cli/pulumi_stack_init/). This PR adds it and the required docs.