### PR TITLE
feat: Add version verification to prevent unnecessary Pulumi CLI reinstallation

### DIFF
--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -42,6 +42,16 @@ commands:
       - run: 
           name: "Install Pulumi CLI, if needed"
           command: |
+              # Check if Pulumi CLI is already installed with specified version
+              if command -v pulumi &> /dev/null; then
+                  INSTALLED_VERSION=$(pulumi version | cut -d 'v' -f2)
+                  if [ "<< parameters.version >>" == "latest" ] || [ "$INSTALLED_VERSION" == "<< parameters.version >>" ]; then
+                      echo "Pulumi CLI v$INSTALLED_VERSION is already installed, skipping installation."
+                      exit 0
+                  else
+                      echo "Pulumi CLI v$INSTALLED_VERSION is installed, but version << parameters.version >> was requested. Updating..."
+                  fi
+              fi
               if [ << parameters.version >> == "latest" ]; then
                 curl -L https://get.pulumi.com/ | bash -s
               else

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -61,6 +61,10 @@ commands:
                 if [ "$INSTALLED_VERSION" == "$TARGET_VERSION" ]; then
                   echo "Pulumi $INSTALLED_VERSION is already installed and matches requested version. Skipping install."
                   exit 0
+                elif [ -z $TARGET_VERSION ]; then
+                    # Pulumi is already installed, and the user didn't override the version. Just continue using what is installed
+                    echo "Using Pulumi $INSTALLED_VERSION"
+                    exit 0
                 else
                   echo "Version mismatch (Installed: $INSTALLED_VERSION, Requested: $TARGET_VERSION). Proceeding with installation."
                 fi

--- a/orbs/pulumi.yml
+++ b/orbs/pulumi.yml
@@ -42,22 +42,36 @@ commands:
       - run: 
           name: "Install Pulumi CLI, if needed"
           command: |
-              # Check if Pulumi CLI is already installed with specified version
-              if command -v pulumi &> /dev/null; then
-                  INSTALLED_VERSION=$(pulumi version | cut -d 'v' -f2)
-                  if [ "<< parameters.version >>" == "latest" ] || [ "$INSTALLED_VERSION" == "<< parameters.version >>" ]; then
-                      echo "Pulumi CLI v$INSTALLED_VERSION is already installed, skipping installation."
-                      exit 0
-                  else
-                      echo "Pulumi CLI v$INSTALLED_VERSION is installed, but version << parameters.version >> was requested. Updating..."
-                  fi
+              PARAM_VERSION="<< parameters.version >>"
+
+              if command -v pulumi > /dev/null; then
+                # Strip 'v' prefix if present (e.g., v3.101.0 -> 3.101.0)
+                INSTALLED_VERSION=$(pulumi version | tr -d 'v')
+                echo "Found installed Pulumi version: $INSTALLED_VERSION"
+
+                # Determine the target version for comparison
+                if [ "$PARAM_VERSION" == "latest" ]; then
+                  TARGET_VERSION=$(curl -s https://www.pulumi.com/latest-version)
+                  echo "Latest available version is: $TARGET_VERSION"
+                else
+                  TARGET_VERSION="$PARAM_VERSION"
+                fi
+
+                # Compare and exit if they match
+                if [ "$INSTALLED_VERSION" == "$TARGET_VERSION" ]; then
+                  echo "Pulumi $INSTALLED_VERSION is already installed and matches requested version. Skipping install."
+                  exit 0
+                else
+                  echo "Version mismatch (Installed: $INSTALLED_VERSION, Requested: $TARGET_VERSION). Proceeding with installation."
+                fi
               fi
-              if [ << parameters.version >> == "latest" ]; then
+
+              if [ "$PARAM_VERSION" == "latest" ]; then
                 curl -L https://get.pulumi.com/ | bash -s
               else
-                curl -L https://get.pulumi.com/ | bash -s -- --version << parameters.version >>
+                curl -L https://get.pulumi.com/ | bash -s -- --version "$PARAM_VERSION"
               fi
-              # Add to PATH
+
               echo 'export PATH=${HOME}/.pulumi/bin:$PATH' >> $BASH_ENV
               source $BASH_ENV
       - run:


### PR DESCRIPTION
# Current Behaviour

Currently, the Orb's `login` command has a comment indicating it will "Install Pulumi CLI, if needed" but the current implementation doesn't fully align with this comment. Namely, it does not check for the existence of the Pulumi CLI.

# Issue

This creates a discrepancy between the documented functionality (in the code comment) and the actual behaviour, potentially leading to unnecessary reinstallation of the Pulumi CLI even when the correct version is already present.

# Changes Made

This PR implements proper version verification to:

1. Check if Pulumi CLI is already installed
2. (If installed) Compare the installed version with the requested version
3. Skip installation if the versions match exactly or if "latest" was requested
4. Otherwise, proceed with installation/update

# Note on Version Matching

I have opted to use exact string matching for version comparison rather than semantic version parsing. This approach works reliably with all version formats, including pre-release versions and release candidates for which I can see a couple in the documented [Pulumi CLI versions](https://www.pulumi.com/docs/iac/download-install/versions/).

Let me know if there are any issues with this or any different design approaches you would like me to consider!

Cheers