### PR TITLE
add @pulumi/platform as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pulumi/platform


### PR DESCRIPTION
We should probably be maintaining this repo, as it's similar to `pulumi/actions`, and `pulumi/pulumi-az-pipelines-task`, which are both maintained by us.